### PR TITLE
add resession extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
 # fsplash.nvim (floating splash screen)
+
 Show a custom splash screen in a floating window.
 
 ![screenshot](https://github.com/jovanlanik/fsplash.nvim/assets/21199271/2e732304-83f5-4217-a4aa-a9e59d82b420)
+
 ## Install
+
 First install using your favorite package manager:
+
 - packer.nvim: `use 'jovanlanik/fsplash'`
 - paq-nvim: `'jovanlanik/fsplash'`
 - lazy.nvim: `'jovanlanik/fsplash'`
 - vim-plug: `Plug 'jovanlanik'`
+
 Then setup fsplash in your config:
+
 ```lua
 require('fsplash').setup()
 ```
+
 ## Configure
+
 The setup function accepts the following options:
+
 ```lua
 require('fsplash').setup({
     -- lines of text containing the splash
@@ -42,5 +51,22 @@ require('fsplash').setup({
 	border = 'solid';
     -- winblend option
 	winblend = 0;
+})
+```
+
+## Third-party Integrations
+
+### resession.nvim
+
+fsplash has built-in support for playing nicely with
+[resession.nvim](https://github.com/stevearc/resession.nvim) session manager
+which simply makes sure the fsplash window is closed before saving/loading a
+session. You can enable the extension when you set up resession.nvim:
+
+```lua
+require('resession').setup({
+    extensions = {
+        fsplash = {}
+    }
 })
 ```

--- a/lua/resession/extensions/fsplash.lua
+++ b/lua/resession/extensions/fsplash.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+local close_fsplash = function()
+	local fsplash = require("fsplash")
+	if fsplash.buffer then
+		fsplash.close_window()
+	end
+end
+
+M.on_save = close_fsplash()
+M.on_load = close_fsplash()
+
+return M


### PR DESCRIPTION
This adds an extension for [resession.nvim](https://github.com/stevearc/resession.nvim) to allow `fsplash` to play nicely with saving/restoring sessions. It's pretty basic and simply checks to see if an `fsplash` buffer is open and closes it on save/load of session. To use this, you would be able to just enable it with the `resession` `setup` call like this:

```lua
require("resession").setup {
  extensions = {
    fsplash = {},
  },
}
```